### PR TITLE
Ability to remove a key/value modifier. Fixes #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ According to BEM, the DOM element that receives a modifier also needs the origin
 
 Example usage:
 ```javascript
+// Add 'hidden' boolean modifier to the 'b-widget' block
+$('.b-widget').setMod('b-widget', 'hidden', true);
+
+// Remove 'hidden' boolean modifier from the 'b-widget' block
 $('.b-widget').setMod('b-widget', 'hidden', false);
 ```
 
@@ -71,13 +75,22 @@ Key/value modifiers are different from boolean modifiers in that they have disti
 
 *modVal* should not be a boolean value, otherwise it will be treated as a boolean modifier.
 
-If you also set *modVal* to an empty String `''`, the modifier will be removed.
+If you also set *modVal* to an empty `String` `''`, the modifier will be removed.
+
+Example usage:
+```javascript
+// Add 'theme' key/value modifier to the 'b-widget' block
+$('.b-widget').setMod('b-widget', 'theme', 'light');
+
+// Remove 'theme' key/value modifier from the 'b-widget' block
+$('.b-widget').setMod('b-widget', 'theme', '');
+```
 
 ### Set a key/value modifier on an element:
 
 `.setMod(blockName, elemName, modName, modVal)`
 
-*modVal* should not be a boolean value.
+Same as above, but the second argument is an element name. *modVal* should not also be a boolean value.
 
 ## getMod
 
@@ -123,24 +136,10 @@ For each modifier being set, a custom jQuery event fires which unique name is fo
 
 For all modifiers (both boolean and key/value pairs), the custom event is formed like this:
 
-`setMod:block_modName_*`  // for blocks
-`setMod:block__elem_modName_*`  // for elements
+For blocks: `setMod:block_modName_*`  
+For elements: `setMod:block__elem_modName_*`
 
-If you define a custom BEM syntax with `$.BEMsyntax()` method, you should adjust your event name patterns accordingly. Events being triggered always use the current syntax.
-
-An asterisk `*` at the end of an event name means it's triggered for all modifier values. An object passed as a second argument to an event handler contains additional keys:
-
-   * `block` — block name
-   * `elem` — element name (`undefined` if modifier is set on a block level)
-   * `modName` — modifier name
-   * `modVal` — modifier value that is set: a boolean `true`/`false` for boolean modifiers, a `String` value for key/value modifiers
-
-For key/value modifier *only*, and *additional* event is triggered which is specific to a modifier value being set. Its custom name is formed like this:
-
-`setMod:block_modName_modVal`  // for blocks
-`setMod:block__elem_modName_modVal`  // for elements
-
-Example:
+**NOTE**: If you define a custom BEM syntax with `$.BEMsyntax()` method, you should adjust your event name patterns accordingly. Events being triggered always use the current syntax.
 
 ```javascript
 $(document).on('setMod:widget_init_*', function(e, data) {
@@ -160,3 +159,38 @@ $('div.widget').setMod('widget', 'init', true);
 
 */
 ```
+
+An asterisk `*` at the end of an event name means it's triggered for all modifier values. An object passed as a second argument to an event handler contains additional keys:
+
+   * `block` — block name
+   * `elem` — element name (`undefined` if modifier is set on a block level)
+   * `modName` — modifier name
+   * `modVal` — modifier value that is set: a boolean `true`/`false` for boolean modifiers, a `String` value for key/value modifiers
+
+**TIP**: For key/value modifier *only*, an *additional* event is triggered which is specific to a modifier value being set. Its custom name is formed like this:
+
+For blocks: `setMod:block_modName_modVal`  
+For elements: `setMod:block__elem_modName_modVal`
+
+```javascript
+$(document).on('setMod:widget_theme_light', function(e, data) {
+    console.log('Block name:', data.block);
+    console.log('Element name:', data.elem);  // undefined, as it's a block-level modifier
+    console.log('Modifier name:', data.modName);
+    console.log('Modifier value:', data.modVal);
+});
+
+$('div.widget').setMod('widget', 'theme', 'light');
+/* Console output:
+
+>  Block name: widget
+>  Element name: undefined
+>  Modifier name: theme
+>  Modifier value: light
+
+*/
+```
+
+So as an example if you set `setMod:widget_theme_light` event listener, then it will be triggered *only* if you set the `theme` key/value modifier's value to `light`. Any other values won't trigger the event listener.
+
+**NOTE**: Please also note that if you have removed the string modifier value by setting it to an empty `String`, `$('div.widget').setMod('widget', 'theme', '');` then the specific event listener won't again be triggered obviously! In such cases you might consider setting the wild-card event listener, just like how you set it for boolean modifiers: `setMod:widget_theme_*`.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # jquery-bemhelpers
 
-BEM helpers for jQuery 
+BEM helpers for jQuery
 
 ## Why you might need it
 
@@ -70,6 +70,8 @@ Key/value modifiers are different from boolean modifiers in that they have disti
 `.setMod(blockName, modName, modVal)`
 
 *modVal* should not be a boolean value, otherwise it will be treated as a boolean modifier.
+
+If you also set *modVal* to an empty String `''`, the modifier will be removed.
 
 ### Set a key/value modifier on an element:
 

--- a/jquery.bemhelpers.js
+++ b/jquery.bemhelpers.js
@@ -80,16 +80,11 @@
                     classPattern = block + (elem !== undefined ? BEMsyntax.elem + elem : '') +
                         BEMsyntax.modBefore + modName;
 
-                var removeTheAlreadySetValue = false;
-
                 if (modVal === false) {
                     $this.removeClass(classPattern);
                 } else if (modVal === true) {
                     $this.addClass(classPattern);
                 } else {
-                    // if the String modifer value is an empty String, then it means that user likes to remove it. So set 'removeTheAlreadySetValue' to true.
-                    if (modVal === '') removeTheAlreadySetValue = true;
-
                     $.each(getElemClasses(this), function(i, c) {
                         if (c.indexOf(classPattern) === 0
                             && c.substr(classPattern.length, BEMsyntax.modKeyVal.length) === BEMsyntax.modKeyVal) {
@@ -98,13 +93,15 @@
                         }
                     });
 
-                    // Check whether we should remove the modifer class or not according to 'removeTheAlreadySetValue'
-                    if (removeTheAlreadySetValue === true) $this.removeClass(classPattern + BEMsyntax.modKeyVal + modVal);
-                    else $this.addClass(classPattern + BEMsyntax.modKeyVal + modVal);
+                    // We have removed the modifier class above, now check only
+                    // if 'modVal' is NOT an empty string, then set a new
+                    // modifier class according to its value. Otherwise
+                    // (if 'modVal' is an empty String) don't do anything!
+                    // Because user liked to remove the modifier class totally
+                    if (modVal !== '') {
+                        $this.addClass(classPattern + BEMsyntax.modKeyVal + modVal);
+                    }
                 }
-
-                // if we're dealing with a String modifer(ONLY if we're dealing with a String modifer 'removeTheAlreadySetValue' may be true) and 'removeTheAlreadySetValue' is true, then it means that user aims to remove the already existing modifier value class.
-                if (removeTheAlreadySetValue === true) modVal = false;
 
                 // after the modifier is set, run the corresponding custom event
                 var args = {
@@ -118,7 +115,7 @@
                 $this.trigger('setMod:' + getEventPattern(block, elem, modName), args);
                 // for boolean modifiers, one can only use the wildcard pattern,
                 // so no need to trigger the same event twice
-                if (typeof modVal !== 'boolean') {
+                if (typeof modVal !== 'boolean' && modVal !== '') {
                     $this.trigger('setMod:' + getEventPattern(block, elem, modName, modVal), args);
                 }
             });

--- a/jquery.bemhelpers.js
+++ b/jquery.bemhelpers.js
@@ -1,11 +1,11 @@
 /**
  * jQuery plugin for basic BEM manipulations.
- * 
+ *
  * @author Max Shirshin
  * @version 2.2.1
  *
  * @thanks K. for the inspiration <3
- * 
+ *
  */
 (function($, undefined) {
 
@@ -45,12 +45,12 @@
                 modName = elem;
                 elem = undefined;
             }
-            
+
             if (this.length) {
                 var classPattern = block + (elem !== undefined ? BEMsyntax.elem + elem : '') +
                         BEMsyntax.modBefore + modName,
                     modVal = false;
-                
+
                 $.each(getElemClasses(this.get(0)), function(i, c) {
                     if (c === classPattern) {
                         modVal = true;
@@ -62,29 +62,34 @@
                         return false;
                     }
                 });
-                
+
                 return modVal;
-                
+
             } else return undefined;
         },
-        
+
         setMod: function(block, elem, modName, modVal) {
             if (modVal === undefined) {
                 modVal = modName;
                 modName = elem;
                 elem = undefined;
             }
-            
+
             return this.each(function() {
                 var $this = $(this),
                     classPattern = block + (elem !== undefined ? BEMsyntax.elem + elem : '') +
                         BEMsyntax.modBefore + modName;
-                
+
+                var removeTheAlreadySetValue = false;
+
                 if (modVal === false) {
                     $this.removeClass(classPattern);
                 } else if (modVal === true) {
                     $this.addClass(classPattern);
                 } else {
+                    // if the String modifer value is an empty String, then it means that user likes to remove it. So set 'removeTheAlreadySetValue' to true.
+                    if (modVal === '') removeTheAlreadySetValue = true;
+
                     $.each(getElemClasses(this), function(i, c) {
                         if (c.indexOf(classPattern) === 0
                             && c.substr(classPattern.length, BEMsyntax.modKeyVal.length) === BEMsyntax.modKeyVal) {
@@ -92,10 +97,15 @@
                             $this.removeClass(c);
                         }
                     });
-                    
-                    $this.addClass(classPattern + BEMsyntax.modKeyVal + modVal);
+
+                    // Check whether we should remove the modifer class or not according to 'removeTheAlreadySetValue'
+                    if (removeTheAlreadySetValue === true) $this.removeClass(classPattern + BEMsyntax.modKeyVal + modVal);
+                    else $this.addClass(classPattern + BEMsyntax.modKeyVal + modVal);
                 }
-                
+
+                // if we're dealing with a String modifer(ONLY if we're dealing with a String modifer 'removeTheAlreadySetValue' may be true) and 'removeTheAlreadySetValue' is true, then it means that user aims to remove the already existing modifier value class.
+                if (removeTheAlreadySetValue === true) modVal = false;
+
                 // after the modifier is set, run the corresponding custom event
                 var args = {
                     block: block,
@@ -118,5 +128,5 @@
             return !! this.getMod(block, elem, modName);
         }
     });
-    
+
 })(jQuery);

--- a/tests/test.html
+++ b/tests/test.html
@@ -78,6 +78,12 @@ function runTests(module, proposedSyntax) {
             assert.strictEqual($el.hasClass('b-block' + syntax.modBefore + 'mod' + syntax.modKeyVal + 'val2'), true);
             assert.strictEqual($el.hasClass('b-block' + syntax.modBefore + 'mod' + syntax.modKeyVal + 'val1'), false);
         });
+
+        $b.setMod('b-block', 'mod', '');
+        $b.each(function (i, el) {
+            var $el = $(el);
+            assert.strictEqual($el.hasClass('b-block' + syntax.modBefore + 'mod' + syntax.modKeyVal + 'val2'), false);
+        });
     });
 
     QUnit.test('setMod on an element, boolean', function(assert) {
@@ -125,6 +131,12 @@ function runTests(module, proposedSyntax) {
             assert.strictEqual($el.hasClass('b-block' + syntax.elem + 'elem1' + syntax.modBefore + 'mod' + syntax.modKeyVal + 'bla'), false);
         });
 
+        $elem.setMod('b-block', 'elem1', 'mod', '');
+        $elem.each(function (i, el) {
+            var $el = $(el);
+            assert.strictEqual($el.hasClass('b-block' + syntax.elem + 'elem1' + syntax.modBefore + 'mod' + syntax.modKeyVal + 'bla2'), false);
+        });
+
     });
 
     QUnit.test('trigger custom event on block modifier set, true', function(assert) {
@@ -166,6 +178,20 @@ function runTests(module, proposedSyntax) {
                     start();
                 })
                 .setMod('b-block', 'mod', 'bla');
+
+    });
+
+    QUnit.test('trigger custom event on block modifier set, removing key/value, wildcard callback', function(assert) {
+        var $b = $f.find('.b-block');
+        var start = assert.async();
+
+        $b
+                .one('setMod:b-block' + syntax.modBefore + 'mod' + syntax.modKeyVal + '*', function (e, data) {
+                    assert.strictEqual(data.modName, 'mod');
+                    assert.strictEqual(data.modVal, '');
+                    start();
+                })
+                .setMod('b-block', 'mod', '');
 
     });
 
@@ -224,6 +250,19 @@ function runTests(module, proposedSyntax) {
 
     });
 
+    QUnit.test('trigger custom event on elem modifier set, removing key/value, wildcard callback', function(assert) {
+        var $elem = $f.find('.b-block' + syntax.elem + 'elem2');
+        var start = assert.async();
+        $elem
+                .one('setMod:b-block' + syntax.elem + 'elem2' + syntax.modBefore + 'mod' + syntax.modKeyVal + '*', function (e, data) {
+                    assert.strictEqual(data.modName, 'mod');
+                    assert.strictEqual(data.modVal, '');
+                    start();
+                })
+                .setMod('b-block', 'elem2', 'mod', '');
+
+    });
+
     QUnit.test('trigger custom event on elem modifier set, key/value, specific callback', function(assert) {
         var $elem = $f.find('.b-block' + syntax.elem + 'elem2');
         var start = assert.async();
@@ -273,6 +312,9 @@ function runTests(module, proposedSyntax) {
         $block.setMod('b-block', 'mod', 'foo');
         assert.strictEqual($block.hasMod('b-block', 'mod'), true);
 
+        $block.setMod('b-block', 'mod', '');
+        assert.strictEqual($block.hasMod('b-block', 'mod'), false);
+
         assert.strictEqual($block.hasMod('b-block', 'mod2'), false);
 
     });
@@ -285,6 +327,9 @@ function runTests(module, proposedSyntax) {
 
         $elem.setMod('b-block', 'elem1', 'mod', 'foo');
         assert.strictEqual($elem.hasMod('b-block', 'elem1', 'mod'), true);
+
+        $elem.setMod('b-block', 'elem1', 'mod', '');
+        assert.strictEqual($elem.hasMod('b-block', 'elem1', 'mod'), false);
 
         assert.strictEqual($elem.hasMod('b-block', 'mod2'), false);
     });


### PR DESCRIPTION
Now you can easily add and also remove a key/value modifier.
If you set the value of the modifier an empty String, then the modifier
will be removed from the block/element:
`$('.t24-button').setMod('t24-button', 'theme', '');`
